### PR TITLE
#5 : [Add] : items 테이블 조회 기능을 구현한다.

### DIFF
--- a/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsConfig.java
+++ b/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsConfig.java
@@ -1,0 +1,20 @@
+package com.teleworkfreak.ondolbangv2.items;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+
+@Configuration
+public class ItemsConfig {
+    private final EntityManager em;
+
+    public ItemsConfig(EntityManager em) {
+        this.em = em;
+    }
+
+    @Bean
+    public ItemsRepository itemsRepository() {
+        return new JPAItemsRepository(em);
+    }
+}

--- a/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsConfig.java
+++ b/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsConfig.java
@@ -14,6 +14,11 @@ public class ItemsConfig {
     }
 
     @Bean
+    public ItemsService itemsService(){
+        return new ItemsService(itemsRepository());
+    }
+
+    @Bean
     public ItemsRepository itemsRepository() {
         return new JPAItemsRepository(em);
     }

--- a/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsController.java
+++ b/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsController.java
@@ -1,0 +1,23 @@
+package com.teleworkfreak.ondolbangv2.items;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
+
+@Controller
+public class ItemsController {
+
+    private ItemsService itemsService;
+
+    public ItemsController(ItemsService itemsService) {
+        this.itemsService = itemsService;
+    }
+    @GetMapping("/")
+    @ResponseBody
+    public List<Items> search(){
+        List<Items> findData = itemsService.findAll();
+        return findData;
+    }
+}

--- a/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsRepository.java
+++ b/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsRepository.java
@@ -1,0 +1,8 @@
+package com.teleworkfreak.ondolbangv2.items;
+
+import java.util.List;
+
+public interface ItemsRepository {
+    List<Items> findAll();
+
+}

--- a/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsService.java
+++ b/src/main/java/com/teleworkfreak/ondolbangv2/items/ItemsService.java
@@ -1,0 +1,17 @@
+package com.teleworkfreak.ondolbangv2.items;
+
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+
+@Transactional
+public class ItemsService {
+    private ItemsRepository itemsRepository;
+
+    public ItemsService(ItemsRepository itemsRepository) {
+        this.itemsRepository = itemsRepository;
+    }
+
+    public List<Items> findAll(){
+        return itemsRepository.findAll();
+    }
+}

--- a/src/main/java/com/teleworkfreak/ondolbangv2/items/JPAItemsRepository.java
+++ b/src/main/java/com/teleworkfreak/ondolbangv2/items/JPAItemsRepository.java
@@ -1,0 +1,19 @@
+package com.teleworkfreak.ondolbangv2.items;
+
+import javax.persistence.EntityManager;
+import java.util.List;
+
+public class JPAItemsRepository implements ItemsRepository {
+
+    private final EntityManager em;
+
+    public JPAItemsRepository(EntityManager em) {
+        this.em = em;
+    }
+
+    @Override
+    public List<Items> findAll() {
+        return em.createQuery("select item from Items item", Items.class)
+                .getResultList();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,6 @@
+spring.datasource.url=jdbc:h2:tcp://localhost/~/test
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.username=sa
 
+spring.jpa.show-sql=true
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
#5
- JPAItemsRepository 및 ItemsRepository를 구현
- ItemsController 구현
- ItemsService 구현
- 관심사를 분리하기 위해 ItemsConfig를 이용하여 DIP에 위배되지 않게 구현함
- 단순 전체 조회기능만이 구현되어 있음
- 추후 여러 검색 조건에 부합하여 리턴할 수 있기 위해 Repository, Controller, Service를 수정해야함.